### PR TITLE
Update redis values to match its chart specification

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -21,9 +21,10 @@ ingress:
 redis:
   enabled: true
   architecture: "standalone"
-  persistence:
-    size: 2Gi
-    storageClass: ""
+  master:
+    persistence:
+      size: 2Gi
+      storageClass: ""
   auth:
     enabled: false
 


### PR DESCRIPTION
The redis chart in the release `15.4.1` specifies the `persistence`
options under the `master` key instead of at the top-level.